### PR TITLE
Workaround for msvc-17 compiler bug

### DIFF
--- a/include/native_streaming/utils/boost_compatibility_utils.hpp
+++ b/include/native_streaming/utils/boost_compatibility_utils.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <string>
+#include <functional>
+#include <boost/beast/core/tcp_stream.hpp>
+#include <boost/beast/websocket/stream.hpp>
+
+#define BEGIN_NAMESPACE_STREAM_UTILS namespace daq { namespace native_streaming { 
+#define END_NAMESPACE_STREAM_UTILS }}
+
+BEGIN_NAMESPACE_STREAM_UTILS
+
+namespace boost_compatibility_utils
+{
+    using BoostHandler = std::function<void(const boost::system::error_code&)>;
+    using WebsocketStream = boost::beast::websocket::stream<boost::beast::tcp_stream>;
+    using WriteCallback = std::function<void(boost::beast::error_code ec, std::size_t written)>;
+
+    void async_handshake(WebsocketStream& stream,
+        const std::string& host,
+        const std::string& target,
+        const BoostHandler& handler);
+
+    void async_accept(WebsocketStream& websocket, const BoostHandler& handler);
+
+    void async_write(boost::beast::tcp_stream& stream,
+                     boost::beast::http::request<boost::beast::http::string_body>& request,
+					 WriteCallback callback);
+}
+
+END_NAMESPACE_STREAM_UTILS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_Include common.hpp
                 session.hpp
                 server.hpp
                 client.hpp
+                utils/boost_compatibility_utils.hpp
 )
 
 prepend_include(${PROJECT_NAME} SRC_Include)
@@ -17,7 +18,19 @@ set(SRC_Cpp logging.cpp
             session.cpp
             server.cpp
             client.cpp
+            utils/boost_compatibility_utils.cpp
 )
+
+if(MSVC)
+    if(${MSVC_VERSION} LESS 1920)
+        # msvc-17 has a compiler bug when cmpiling functions defined in boost_compatibility_utils
+        # this is why we compile them using cxx_std_14
+        set_source_files_properties(
+            utils/boost_compatibility_utils.cpp
+            PROPERTIES COMPILE_FLAGS /std:c++14
+        )
+    endif()
+endif()
 
 add_library(${PROJECT_NAME} STATIC ${SRC_Include} ${SRC_Cpp})
 add_library(daq::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,5 +1,6 @@
 #include <native_streaming/client.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <native_streaming/utils/boost_compatibility_utils.hpp>
 
 BEGIN_NAMESPACE_NATIVE_STREAMING
 
@@ -79,13 +80,14 @@ void Client::onConnect(const boost::system::error_code& ec, std::shared_ptr<Webs
         [](boost::beast::websocket::request_type& req)
         { req.set(boost::beast::http::field::user_agent, std::string(BOOST_BEAST_VERSION_STRING) + " openDAQ-streaming-client"); }));
 
-    wsStream->async_handshake(host,
-                              path,
-                              [this, weak_self = weak_from_this(), wsStream](const boost::system::error_code& ec)
-                              {
-                                  if (auto shared_self = weak_self.lock())
-                                      onUpgradeConnection(ec, wsStream);
-                              });
+    boost_compatibility_utils::async_handshake(*wsStream,
+                                               host,
+                                               path,
+                                               [this, weak_self = weak_from_this(), wsStream](const boost::system::error_code& ec)
+                                               {
+                                                   if (auto shared_self = weak_self.lock())
+                                                       onUpgradeConnection(ec, wsStream);
+                                               });
 }
 
 void Client::onUpgradeConnection(const boost::system::error_code& ec, std::shared_ptr<WebsocketStream> wsStream)

--- a/src/utils/boost_compatibility_utils.cpp
+++ b/src/utils/boost_compatibility_utils.cpp
@@ -1,0 +1,30 @@
+#include "native_streaming/utils/boost_compatibility_utils.hpp"
+#include <string>
+#include <functional>
+#include <boost/beast/websocket/stream.hpp>
+
+BEGIN_NAMESPACE_STREAM_UTILS
+
+namespace boost_compatibility_utils
+{
+    void async_handshake(WebsocketStream& stream,
+                         const std::string& host,
+                         const std::string& target,
+                         const BoostHandler& handler)
+    {
+        stream.async_handshake(host, target, handler);
+    }
+
+    void async_accept(WebsocketStream& websocket, const BoostHandler& handler)
+    {
+        websocket.async_accept(handler);
+    }
+
+    void async_write(boost::beast::tcp_stream& stream,
+        boost::beast::http::request<boost::beast::http::string_body>& request, WriteCallback callback)
+    {
+        boost::beast::http::async_write(stream, request, callback);
+    }
+}
+
+END_NAMESPACE_STREAM_UTILS


### PR DESCRIPTION
Compiler: msvc-17 Win32 Release

Error: 
`fatal error C1001: An internal error has occurred in the compiler.
  (compiler file 'd:\a01\_work\12\s\src\vctools\compiler\utc\src\p2\main.c', line 187)
   To work around this problem, try simplifying or changing the program near the locations listed above.
  Please choose the Technical Support command on the Visual C++
   Help menu, or open the Technical Support help file for more information
  Internal Compiler Error in C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.16.27023\bin\HostX86\x86\CL.exe.  You will be prompted to send an error report to Microsoft later.
  cl : Command line error D8040 : error creating or communicating with child process`

The same workaround is used in libstream (https://github.com/openDAQ/libstream/blob/c30615cfda20004b052f34bed18a5b4e7e284cd8/src/utils/boost_compatibility_utils.cpp)