### PR TITLE
Other/small optimizations

### DIFF
--- a/include/native_streaming/logging.hpp
+++ b/include/native_streaming/logging.hpp
@@ -33,11 +33,21 @@ BEGIN_NAMESPACE_NATIVE_STREAMING
 
 #define NS_LOG_W(message, ...) LOG(logCallback, spdlog::level::warn, message, ##__VA_ARGS__)
 
+#ifndef NDEBUG
+
 #define NS_LOG_T(message, ...) LOG(logCallback, spdlog::level::trace, message, ##__VA_ARGS__)
 
-#define NS_LOG_C(message, ...) LOG(logCallback, spdlog::level::critical, message, ##__VA_ARGS__)
-
 #define NS_LOG_D(message, ...) LOG(logCallback, spdlog::level::debug, message, ##__VA_ARGS__)
+
+#else
+
+#define NS_LOG_T(message, ...)
+
+#define NS_LOG_D(message, ...)
+
+#endif
+
+#define NS_LOG_C(message, ...) LOG(logCallback, spdlog::level::critical, message, ##__VA_ARGS__)
 
 using LogCallback = std::function<void(spdlog::source_loc location, spdlog::level::level_enum level, const char* msg)>;
 

--- a/src/async_writer.cpp
+++ b/src/async_writer.cpp
@@ -1,5 +1,6 @@
 #include <native_streaming/async_writer.hpp>
 #include <boost/asio/read.hpp>
+#include <boost/container/small_vector.hpp>
 
 BEGIN_NAMESPACE_NATIVE_STREAMING
 
@@ -71,8 +72,7 @@ void AsyncWriter::doWrite(const BatchedWriteTasksWithDeadline& tasksWithDeadline
 
     const auto& tasks = tasksWithDeadline.first;
 
-    std::vector<boost::asio::const_buffer> buffers;
-    buffers.reserve(tasks.size());
+    boost::container::small_vector<boost::asio::const_buffer, 16> buffers;
 
     for (const auto& task : tasks)
     {


### PR DESCRIPTION
Some small opimization opportunites found during openDAQ profiling:

1) Trace and debug logging is enabled even in release mode. The messages itself are not logged, however, they are constructed with std::format. Trace logging happens every time a packet is written to boost asio (AsyncWriter::writeDone)

2) Using boost::small_vector for task construction. Small vector is allocated on a stack if number of items is smaller than templated parameter, therefore no heap allocation occurs.