### PR TITLE
Fix endpoint port value type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(native_streaming VERSION 1.0.17 LANGUAGES CXX)
+project(native_streaming VERSION 1.0.18 LANGUAGES CXX)
 
 if (NOT CMAKE_MESSAGE_CONTEXT)
     set(CMAKE_MESSAGE_CONTEXT ${PROJECT_NAME})

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/async_reader.hpp
+++ b/include/native_streaming/async_reader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/async_writer.hpp
+++ b/include/native_streaming/async_writer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/authentication.hpp
+++ b/include/native_streaming/authentication.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/client.hpp
+++ b/include/native_streaming/client.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/client.hpp
+++ b/include/native_streaming/client.hpp
@@ -73,7 +73,7 @@ private:
     /// @return pointer to created Session object
     std::shared_ptr<Session> createSession(std::shared_ptr<WebsocketStream> wsStream,
                                            const std::string& endpointAddress,
-                                           const boost::asio::ip::port_type& endpointPortNumber);
+                                           const uint16_t& endpointPortNumber);
 
     /// async operations handler
     std::shared_ptr<boost::asio::io_context> ioContextPtr;

--- a/include/native_streaming/common.hpp
+++ b/include/native_streaming/common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/logging.hpp
+++ b/include/native_streaming/logging.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/server.hpp
+++ b/include/native_streaming/server.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/server.hpp
+++ b/include/native_streaming/server.hpp
@@ -89,7 +89,7 @@ private:
     std::shared_ptr<Session> createSession(std::shared_ptr<WebsocketStream> wsStream,
                                            const std::shared_ptr<void>& userContext,
                                            const std::string& endpointAddress,
-                                           const boost::asio::ip::port_type& endpointPortNumber);
+                                           const uint16_t& endpointPortNumber);
 
     /// async operations handler
     std::shared_ptr<boost::asio::io_context> ioContextPtr;

--- a/include/native_streaming/session.hpp
+++ b/include/native_streaming/session.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/session.hpp
+++ b/include/native_streaming/session.hpp
@@ -38,7 +38,7 @@ public:
                      boost::beast::role_type role,
                      LogCallback logCallback,
                      const std::string& endpointAddress,
-                     const boost::asio::ip::port_type& endpointPortNumber);
+                     const uint16_t& endpointPortNumber);
     ~Session();
 
     Session(const Session&) = delete;
@@ -79,7 +79,7 @@ public:
     std::string getEndpointAddress();
 
     /// @brief returns a port number of the connection endpoint associated with the session.
-    boost::asio::ip::port_type getEndpointPortNumber();
+    uint16_t getEndpointPortNumber();
 
     /// @brief sets a callback to be called when the write operation has not been scheduled due to a timeout reached
     /// @param writeTaskTimeoutHandler callback
@@ -130,7 +130,7 @@ private:
     std::string endpointAddress;
 
     /// @brief port number of the connection endpoint associated with the session
-    boost::asio::ip::port_type endpointPortNumber;
+    uint16_t endpointPortNumber;
 };
 
 END_NAMESPACE_NATIVE_STREAMING

--- a/include/native_streaming/utils/base64.hpp
+++ b/include/native_streaming/utils/base64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/native_streaming/utils/boost_compatibility_utils.hpp
+++ b/include/native_streaming/utils/boost_compatibility_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -157,7 +157,7 @@ void Client::onUpgradeConnection(const boost::system::error_code& ec, std::share
     }
 
     std::string endpointAddress;
-    boost::asio::ip::port_type endpointPortNumber;
+    uint16_t endpointPortNumber;
     try
     {
         auto remoteEp = wsStream->next_layer().socket().remote_endpoint();
@@ -175,7 +175,7 @@ void Client::onUpgradeConnection(const boost::system::error_code& ec, std::share
 
 std::shared_ptr<Session> Client::createSession(std::shared_ptr<WebsocketStream> wsStream,
                                                const std::string& endpointAddress,
-                                               const boost::asio::ip::port_type& endpointPortNumber)
+                                               const uint16_t& endpointPortNumber)
 {
     websocketStream.reset();
     return std::make_shared<Session>(ioContextPtr, wsStream, nullptr, boost::beast::role_type::client, logCallback, endpointAddress, endpointPortNumber);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -213,7 +213,7 @@ void Server::onUpgradeConnection(const boost::system::error_code& ec,
     // it throws an exception when attempting to retrieve the endpoint address.
     // To handle this, first verify the socket state and then safely attempt to retrieve the endpoint name.
     std::string endpointAddress;
-    boost::asio::ip::port_type endpointPortNumber;
+    uint16_t endpointPortNumber;
     if (!(wsStream->is_open() && wsStream->next_layer().socket().is_open()))
     {
         NS_LOG_W("Websocket connection aborted: the socket is already closed");
@@ -241,7 +241,7 @@ void Server::onUpgradeConnection(const boost::system::error_code& ec,
 std::shared_ptr<Session> Server::createSession(std::shared_ptr<WebsocketStream> wsStream,
                                                const std::shared_ptr<void>& userContext,
                                                const std::string& endpointAddress,
-                                               const boost::asio::ip::port_type& endpointPortNumber)
+                                               const uint16_t& endpointPortNumber)
 {
     return std::make_shared<Session>(ioContextPtr, wsStream, userContext, boost::beast::role_type::server, logCallback, endpointAddress, endpointPortNumber);
 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -11,7 +11,7 @@ Session::Session(std::shared_ptr<boost::asio::io_context> ioContextPtr,
                  boost::beast::role_type role,
                  LogCallback logCallback,
                  const std::string& endpointAddress,
-                 const boost::asio::ip::port_type& endpointPortNumber)
+                 const uint16_t& endpointPortNumber)
     : role(role)
     , logCallback(logCallback)
     , ioContextPtr(ioContextPtr)
@@ -180,7 +180,7 @@ std::string Session::getEndpointAddress()
     return endpointAddress;
 }
 
-boost::asio::ip::port_type Session::getEndpointPortNumber()
+uint16_t Session::getEndpointPortNumber()
 {
     return endpointPortNumber;
 }

--- a/test/test_base.hpp
+++ b/test/test_base.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/test_connection.hpp
+++ b/test/test_connection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/license-header-checker/do-license-header-check.sh
+++ b/tools/license-header-checker/do-license-header-check.sh
@@ -2,7 +2,7 @@
 
 : '
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/license-header-checker/license.in
+++ b/tools/license-header-checker/license.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 openDAQ d.o.o.
+ * Copyright 2022-2025 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replaces the Boost-defined type with a plain unsigned short for the endpoint port number, as the custom Boost type (typedef uint16_t) is not available in older Boost versions.
Updates license header